### PR TITLE
Fix commit tree creation

### DIFF
--- a/src/pages/NewRepository.tsx
+++ b/src/pages/NewRepository.tsx
@@ -9,7 +9,7 @@ import { useAppContext } from '../context/AppContext';
 import FileTree from '../components/FileTree';
 import { useToast } from '../components/ui/Toaster';
 import { FileEntry, Repository } from '../types';
-import { processUploadedFiles, getFilesForCommit } from '../utils/fileProcessor';
+import { processUploadedFiles, getFilesForCommit, flattenFileTree } from '../utils/fileProcessor';
 import { validateRepositoryName } from '../utils/validation';
 import { createRepository, createCommit } from '../utils/github';
 import { useLocation } from 'react-router-dom';
@@ -218,12 +218,13 @@ const NewRepository: React.FC = () => {
           files: files
         };
         await createRepository(activeAccount, repositoryObject, false);
+        const allFiles = flattenFileTree(files);
         await createCommit(
           activeAccount,
           repoName,
           branchName,
           commitMessage,
-          files.filter(file => selectedFiles.includes(file.path))
+          allFiles.filter(file => selectedFiles.includes(file.path))
         );
       }
       

--- a/src/utils/fileProcessor.ts
+++ b/src/utils/fileProcessor.ts
@@ -181,3 +181,24 @@ const shouldIgnore = (path: string, ignorePatterns: string[]): boolean => {
   }
   return false;
 };
+
+export const flattenFileTree = (entries: FileEntry[]): FileEntry[] => {
+  const result: FileEntry[] = [];
+
+  const walk = (entry: FileEntry, currentPath: string = '') => {
+    const fullPath = currentPath ? `${currentPath}/${entry.path}` : entry.path;
+    if (entry.type === 'file') {
+      result.push({ ...entry, path: fullPath });
+    } else if (entry.children) {
+      for (const child of entry.children) {
+        walk(child, fullPath);
+      }
+    }
+  };
+
+  for (const entry of entries) {
+    walk(entry);
+  }
+
+  return result;
+};

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -79,7 +79,7 @@ export const createCommit = async (
   // as it would need to handle multiple files, directories, etc.
   
   // First, check if the repository exists
-  const repoResponse = await fetch(`https://api.github.com/repos/${account.username}/${repoName}`, {
+  const repoResponse = await fetch(`https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}`, {
     headers: {
       Authorization: `token ${account.token}`,
       Accept: 'application/vnd.github.v3+json',
@@ -96,7 +96,7 @@ export const createCommit = async (
       .filter(file => file.type === 'file')
       .map(async file => {
         // Create a blob for the file
-        const blobResponse = await fetch(`https://api.github.com/repos/${account.username}/${repoName}/git/blobs`, {
+        const blobResponse = await fetch(`https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/git/blobs`, {
           method: 'POST',
           headers: {
             Authorization: `token ${account.token}`,
@@ -127,7 +127,7 @@ export const createCommit = async (
 
   // Get the SHA of the current branch
   const refResponse = await fetch(
-    `https://api.github.com/repos/${account.username}/${repoName}/git/refs/heads/${branch}`,
+    `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/git/refs/heads/${encodeURIComponent(branch)}`,
     {
       headers: {
         Authorization: `token ${account.token}`,
@@ -141,7 +141,7 @@ export const createCommit = async (
   if (!refResponse.ok) {
     // Get the default branch
     const defaultBranchResponse = await fetch(
-      `https://api.github.com/repos/${account.username}/${repoName}`,
+      `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}`,
       {
         headers: {
           Authorization: `token ${account.token}`,
@@ -159,7 +159,7 @@ export const createCommit = async (
     
     // Get the SHA of the default branch
     const defaultBranchResponse2 = await fetch(
-      `https://api.github.com/repos/${account.username}/${repoName}/git/refs/heads/${defaultBranch}`,
+      `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/git/refs/heads/${encodeURIComponent(defaultBranch)}`,
       {
         headers: {
           Authorization: `token ${account.token}`,
@@ -185,7 +185,7 @@ export const createCommit = async (
   if (baseSha) treeBody.base_tree = baseSha;
 
   const treeResponse = await fetch(
-    `https://api.github.com/repos/${account.username}/${repoName}/git/trees`,
+    `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/git/trees`,
     {
       method: 'POST',
       headers: {
@@ -208,7 +208,7 @@ export const createCommit = async (
   if (baseSha) commitBody.parents = [baseSha];
 
   const commitResponse = await fetch(
-    `https://api.github.com/repos/${account.username}/${repoName}/git/commits`,
+    `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/git/commits`,
     {
       method: 'POST',
       headers: {
@@ -228,8 +228,8 @@ export const createCommit = async (
 
   // Update or create the reference
   const updateRefUrl = refResponse.ok
-    ? `https://api.github.com/repos/${account.username}/${repoName}/git/refs/heads/${branch}`
-    : `https://api.github.com/repos/${account.username}/${repoName}/git/refs`;
+    ? `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/git/refs/heads/${encodeURIComponent(branch)}`
+    : `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/git/refs`;
   const updateRefMethod = refResponse.ok ? 'PATCH' : 'POST';
   const updateRefBody = refResponse.ok
     ? { sha: commitData.sha, force: false }
@@ -272,7 +272,7 @@ export const deleteRepository = async (
   repoName: string
 ) => {
   const response = await fetch(
-    `https://api.github.com/repos/${account.username}/${repoName}`,
+    `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}`,
     {
       method: 'DELETE',
       headers: {
@@ -296,7 +296,7 @@ export const transferRepository = async (
   newOwner: string
 ) => {
   const response = await fetch(
-    `https://api.github.com/repos/${account.username}/${repoName}/transfer`,
+    `https://api.github.com/repos/${account.username}/${encodeURIComponent(repoName)}/transfer`,
     {
       method: 'POST',
       headers: {

--- a/test/fileProcessor.test.mjs
+++ b/test/fileProcessor.test.mjs
@@ -19,7 +19,7 @@ if (!existsSync(outputFile)) {
   ], { stdio: 'inherit' });
 }
 
-const { processUploadedFiles, getFilesForCommit } = await import('../dist-test/utils/fileProcessor.js');
+const { processUploadedFiles, getFilesForCommit, flattenFileTree } = await import('../dist-test/utils/fileProcessor.js');
 
 test('processUploadedFiles handles single file', async () => {
   const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
@@ -62,4 +62,14 @@ test('getFilesForCommit filters by ignore patterns', () => {
   ];
   const files = getFilesForCommit(tree, ['node_modules/*']);
   assert.deepEqual(files, ['file1.txt']);
+});
+
+test('flattenFileTree returns entries with full paths', () => {
+  const tree = [
+    { path: 'src', type: 'directory', children: [
+      { path: 'index.js', type: 'file', content: 'x' }
+    ] }
+  ];
+  const flat = flattenFileTree(tree);
+  assert.deepEqual(flat.map(f => f.path), ['src/index.js']);
 });


### PR DESCRIPTION
## Summary
- gather all uploaded files when creating repository commits
- expose a `flattenFileTree` helper to get full file paths
- test that file tree flattening works
- encode repository and branch names when calling GitHub APIs

## Testing
- `npm test`
- `npm run lint` *(fails: 17 errors, 4 warnings)*