### PR TITLE
Add repo name from uploaded folder

### DIFF
--- a/src/pages/NewRepository.tsx
+++ b/src/pages/NewRepository.tsx
@@ -9,7 +9,7 @@ import { useAppContext } from '../context/AppContext';
 import FileTree from '../components/FileTree';
 import { useToast } from '../components/ui/Toaster';
 import { FileEntry, Repository } from '../types';
-import { processUploadedFiles, getFilesForCommit, flattenFileTree } from '../utils/fileProcessor';
+import { processUploadedFiles, getFilesForCommit, flattenFileTree, deriveRepoNameFromUpload } from '../utils/fileProcessor';
 import { validateRepositoryName } from '../utils/validation';
 import { createRepository, createCommit } from '../utils/github';
 import { useLocation } from 'react-router-dom';
@@ -97,6 +97,11 @@ const NewRepository: React.FC = () => {
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     if (acceptedFiles.length === 0) return;
     const filesToProcess = acceptedFiles;
+
+    const suggestedName = deriveRepoNameFromUpload(acceptedFiles);
+    if (suggestedName) {
+      setRepoName(suggestedName);
+    }
 
     setIsProcessing(true);
     try {

--- a/src/utils/fileProcessor.ts
+++ b/src/utils/fileProcessor.ts
@@ -225,3 +225,24 @@ export const flattenFileTree = (entries: FileEntry[]): FileEntry[] => {
 
   return result;
 };
+
+export const deriveRepoNameFromUpload = (files: File[]): string | null => {
+  if (files.length === 0) return null;
+
+  // Single zip file upload
+  if (files.length === 1 && files[0].name.toLowerCase().endsWith('.zip')) {
+    return files[0].name.replace(/\.zip$/i, '');
+  }
+
+  // Look for a file with a relative path to infer folder name
+  const fileWithPath = files.find(f => (f as any).webkitRelativePath);
+  if (fileWithPath) {
+    const relPath = (fileWithPath as any).webkitRelativePath as string;
+    if (relPath.includes('/')) {
+      const folder = relPath.split('/')[0];
+      if (folder) return folder;
+    }
+  }
+
+  return null;
+};

--- a/test/fileProcessor.test.mjs
+++ b/test/fileProcessor.test.mjs
@@ -19,7 +19,7 @@ if (!existsSync(outputFile)) {
   ], { stdio: 'inherit' });
 }
 
-const { processUploadedFiles, getFilesForCommit, flattenFileTree } = await import('../dist-test/utils/fileProcessor.js');
+const { processUploadedFiles, getFilesForCommit, flattenFileTree, deriveRepoNameFromUpload } = await import('../dist-test/utils/fileProcessor.js');
 
 test('processUploadedFiles handles single file', async () => {
   const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
@@ -72,4 +72,17 @@ test('flattenFileTree returns entries with full paths', () => {
   ];
   const flat = flattenFileTree(tree);
   assert.deepEqual(flat.map(f => f.path), ['src/index.js']);
+});
+
+test('deriveRepoNameFromUpload detects folder name', () => {
+  const f1 = new File(['x'], 'file.txt', { type: 'text/plain' });
+  Object.defineProperty(f1, 'webkitRelativePath', { value: 'myfolder/file.txt' });
+  const name = deriveRepoNameFromUpload([f1]);
+  assert.equal(name, 'myfolder');
+});
+
+test('deriveRepoNameFromUpload uses zip name', () => {
+  const zip = new File(['z'], 'archive.zip', { type: 'application/zip' });
+  const name = deriveRepoNameFromUpload([zip]);
+  assert.equal(name, 'archive');
 });


### PR DESCRIPTION
## Summary
- add `deriveRepoNameFromUpload` to get a repo name from uploaded files
- use the derived name in the New Repository workflow
- test deriving repo name for folder and zip uploads

## Testing
- `npm test`