### PR TITLE
Add multi-account repo view

### DIFF
--- a/src/pages/Repositories.tsx
+++ b/src/pages/Repositories.tsx
@@ -8,6 +8,7 @@ import {
 } from '../utils/github';
 import { Button } from '../components/ui/Button';
 import { useToast } from '../components/ui/Toaster';
+import { GithubAccount } from '../types';
 
 interface Repo {
   id: number;
@@ -15,6 +16,10 @@ interface Repo {
   full_name: string;
   description?: string;
   html_url: string;
+}
+
+interface RepoWithAccount extends Repo {
+  account: GithubAccount;
 }
 
 interface Org {
@@ -26,21 +31,59 @@ const Repositories: React.FC = () => {
   const { accounts, activeAccountId } = useAppContext();
   const activeAccount = accounts.find(a => a.id === activeAccountId);
   const { addToast } = useToast();
-  const [repos, setRepos] = useState<Repo[]>([]);
-  const [orgs, setOrgs] = useState<Org[]>([]);
+  const [viewMode, setViewMode] = useState<'active' | 'all'>('active');
+  const [repos, setRepos] = useState<RepoWithAccount[]>([]);
+  const [orgsMap, setOrgsMap] = useState<Record<string, Org[]>>({});
   const [transferTargets, setTransferTargets] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (!activeAccount) return;
-    fetchUserRepositories(activeAccount.token)
-      .then(setRepos)
-      .catch(err => console.error(err));
-    fetchUserOrganizations(activeAccount.token)
-      .then(setOrgs)
-      .catch(err => console.error(err));
-  }, [activeAccount]);
+    const load = async () => {
+      if (viewMode === 'active') {
+        if (!activeAccount) {
+          setRepos([]);
+          setOrgsMap({});
+          return;
+        }
+        try {
+          const [r, o] = await Promise.all([
+            fetchUserRepositories(activeAccount.token),
+            fetchUserOrganizations(activeAccount.token),
+          ]);
+          setRepos(r.map(repo => ({ ...repo, account: activeAccount })));
+          setOrgsMap({ [activeAccount.id]: o });
+        } catch (err) {
+          console.error(err);
+        }
+      } else {
+        try {
+          const repoPromises = accounts.map(acc =>
+            fetchUserRepositories(acc.token).then(list =>
+              list.map(repo => ({ ...repo, account: acc }))
+            )
+          );
+          const orgPromises = accounts.map(acc =>
+            fetchUserOrganizations(acc.token).then(orgs => [acc.id, orgs] as const)
+          );
+          const [repoResults, orgResults] = await Promise.all([
+            Promise.all(repoPromises),
+            Promise.all(orgPromises),
+          ]);
+          setRepos(repoResults.flat());
+          const map: Record<string, Org[]> = {};
+          for (const [id, list] of orgResults) {
+            map[id] = list;
+          }
+          setOrgsMap(map);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    };
 
-  if (!activeAccount) {
+    load();
+  }, [viewMode, activeAccount, accounts]);
+
+  if (viewMode === 'active' && !activeAccount) {
     return (
       <div className="container mx-auto max-w-4xl p-6 text-center">
         <p className="text-gray-500 dark:text-gray-400">Select an account first.</p>
@@ -48,10 +91,10 @@ const Repositories: React.FC = () => {
     );
   }
 
-  const handleDelete = async (name: string) => {
+  const handleDelete = async (repo: RepoWithAccount) => {
     try {
-      await deleteRepository(activeAccount, name);
-      setRepos(repos.filter(r => r.name !== name));
+      await deleteRepository(repo.account, repo.name);
+      setRepos(repos.filter(r => r.id !== repo.id));
       addToast({ title: 'Repository deleted', type: 'info' });
     } catch (error) {
       addToast({
@@ -62,11 +105,11 @@ const Repositories: React.FC = () => {
     }
   };
 
-  const handleTransfer = async (name: string) => {
-    const target = transferTargets[name];
+  const handleTransfer = async (repo: RepoWithAccount) => {
+    const target = transferTargets[repo.full_name];
     if (!target) return;
     try {
-      await transferRepository(activeAccount, name, target);
+      await transferRepository(repo.account, repo.name, target);
       addToast({ title: 'Repository transferred', type: 'success' });
     } catch (error) {
       addToast({
@@ -80,6 +123,30 @@ const Repositories: React.FC = () => {
   return (
     <div className="container mx-auto max-w-4xl">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+        <div className="mb-4 border-b border-gray-200 dark:border-gray-700">
+          <nav className="-mb-px flex space-x-4">
+            <button
+              className={`px-3 py-2 text-sm font-medium border-b-2 focus:outline-none ${
+                viewMode === 'active'
+                  ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
+              }`}
+              onClick={() => setViewMode('active')}
+            >
+              Active Account
+            </button>
+            <button
+              className={`px-3 py-2 text-sm font-medium border-b-2 focus:outline-none ${
+                viewMode === 'all'
+                  ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
+              }`}
+              onClick={() => setViewMode('all')}
+            >
+              All Accounts
+            </button>
+          </nav>
+        </div>
         <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4">
           Repositories
         </h2>
@@ -98,6 +165,9 @@ const Repositories: React.FC = () => {
                   >
                     {repo.full_name}
                   </a>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {repo.account.username}
+                  </p>
                   {repo.description && (
                     <p className="text-sm text-gray-500 dark:text-gray-400">
                       {repo.description}
@@ -106,17 +176,17 @@ const Repositories: React.FC = () => {
                 </div>
                 <div className="flex items-center space-x-2">
                   <select
-                    value={transferTargets[repo.name] || ''}
+                    value={transferTargets[repo.full_name] || ''}
                     onChange={e =>
                       setTransferTargets({
                         ...transferTargets,
-                        [repo.name]: e.target.value,
+                        [repo.full_name]: e.target.value,
                       })
                     }
                     className="border rounded-md text-sm px-2 py-1 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   >
                     <option value="">Transfer to...</option>
-                    {orgs.map(org => (
+                    {(orgsMap[repo.account.id] || []).map(org => (
                       <option key={org.id} value={org.login}>
                         {org.login}
                       </option>
@@ -125,15 +195,15 @@ const Repositories: React.FC = () => {
                   <Button
                     size="sm"
                     variant="outline"
-                    onClick={() => handleTransfer(repo.name)}
-                    disabled={!transferTargets[repo.name]}
+                    onClick={() => handleTransfer(repo)}
+                    disabled={!transferTargets[repo.full_name]}
                   >
                     Transfer
                   </Button>
                   <Button
                     size="sm"
                     variant="destructive"
-                    onClick={() => handleDelete(repo.name)}
+                    onClick={() => handleDelete(repo)}
                   >
                     Delete
                   </Button>


### PR DESCRIPTION
## Summary
- allow repository page to switch between active and all accounts
- aggregate repositories and organizations across accounts
- keep existing single-account logic

## Testing
- `npm test`
- `npm run lint` *(fails: 21 errors)*